### PR TITLE
allow NMI user routines

### DIFF
--- a/include/basic/basic32k-r36.asm
+++ b/include/basic/basic32k-r36.asm
@@ -209,7 +209,8 @@ SERABITS        equ     SERIALS_EN+$01  ; (1) serial port A data bits
 PBUFF           equ     SERABITS+$01    ; (13) Number print buffer
 MULVAL          equ     PBUFF+$0D       ; (3) Multiplier
 PROGST          equ     MULVAL+$03      ; (100) Start of program text area
-STLOOK          equ     PROGST+$64      ; Start of memory test
+NMIUSR          equ     PROGST+$02      ; NMI exit point routine
+STLOOK          equ     NMIUSR+$64      ; Start of memory test
 
 ; BASIC ERROR CODE VALUES
 ; These values act as an offset to point to the error message into the error table
@@ -694,6 +695,7 @@ INITAB: jp      WARMST          ; Warm start jump
         defw    STLOOK          ; Temp string space
         defw    -2              ; Current line number (cold)
         defw    PROGST+1        ; Start of program text
+        db      $ED,$45,$00     ; NMI (VDP) routine exit point (RETN+NOP)
 INITBE:
 
 ; END OF INITIALISATION TABLE ---------------------------------------------------

--- a/include/basic/basic32k-r36.asm
+++ b/include/basic/basic32k-r36.asm
@@ -208,9 +208,10 @@ SERIALS_EN      equ     CONTROLKEYS+$01 ; (1) serial ports status: bit 0 for Por
 SERABITS        equ     SERIALS_EN+$01  ; (1) serial port A data bits
 PBUFF           equ     SERABITS+$01    ; (13) Number print buffer
 MULVAL          equ     PBUFF+$0D       ; (3) Multiplier
-PROGST          equ     MULVAL+$03      ; (100) Start of program text area
-NMIUSR          equ     PROGST+$02      ; NMI exit point routine
-STLOOK          equ     NMIUSR+$64      ; Start of memory test
+NMIUSR          equ     MULVAL+$03      ; (3) NMI exit point routine
+PROGST          equ     NMIUSR+$03      ; (100) Start of program text area
+STLOOK          equ     PROGST+$64      ; Start of memory test
+
 
 ; BASIC ERROR CODE VALUES
 ; These values act as an offset to point to the error message into the error table
@@ -695,7 +696,6 @@ INITAB: jp      WARMST          ; Warm start jump
         defw    STLOOK          ; Temp string space
         defw    -2              ; Current line number (cold)
         defw    PROGST+1        ; Start of program text
-        db      $ED,$45,$00     ; NMI (VDP) routine exit point (RETN+NOP)
 INITBE:
 
 ; END OF INITIALISATION TABLE ---------------------------------------------------

--- a/include/bootloader/bootloader-r36.asm
+++ b/include/bootloader/bootloader-r36.asm
@@ -165,7 +165,7 @@ RST18:          jp      CKINCHAR
 ;------------------------------------------------------------------------------
 ; interrupt routine for NMI (currently NOT used)
                 org     $0066
-                retn                    ; return from NMI
+                jp      NMIUSR          ; jumps to NMI user routine
 
 ;------------------------------------------------------------------------------
 
@@ -416,7 +416,10 @@ CHKCRSR:        call    FLASHCURSOR     ; call the flashing cursor routine
 ; HARDWARE INITIALISATION
 ; first run - setup HW & SW
 ;
-INIT_HW:        ld      HL,TEMPSTACK    ; load temp stack pointer
+INIT_HW:
+                ld      HL, $45ED       ; "RETN" instruction
+                ld      (NMIUSR), HL    ; set NMI exit point to RETN
+                ld      HL,TEMPSTACK    ; load temp stack pointer
                 ld      SP,HL           ; set stack to temp stack pointer
                 ld      HL,SERBUF_START ; set beginning of input buffer
                 ld      (serInPtr),HL   ; for incoming chars to store into buffer


### PR DESCRIPTION
do not merge, this is a ~~(not working)~~ proposal.

I tried to allow users to have their own VDP interrupt routine that in the LM80C is attached to the NMI interrupt. Such interrupt is triggered by the VDP at reach of line 193 (end of active area) and is useful in games for flicker-free and tear-free screen updates because they occur when the raster is out of the active area. 

With this pull request, the NMI jumps in RAM to a specified location `NMIUSR` in the basic workspace. There, three bytes `$ED,$45,$00` are contained forming a `RETN` + `NOP` instructions. So normally the NMI interrupt does `RETN` as before.

Now, when the user wants to implement his custom routine, he can change the above three bytes into a `JP somewhere`. To make that safely, avoiding the NMI triggering during the change, it should be like this:

```
CHANGE:
LD A,<MYROUTINE   
LD L,>MYROUTINE
LD H,$C3   ; JP 
LD (NMIUSR+2),A
LD (NMIUSR),HL
RET

MYROUTINE:
; awesome graphics here
RETN
```

The bootloader also needs to write `$ED,$45,$00` into `NMIUSR` as soon as possible after the boot (is it safe to assume there's enough time to do that?).

~~My only problem is that it doesn't seem to work. It hangs after a while in the middle of the boot welcome message. I guess `NMIUSR` gets corrupted because I didn't allocate it properly in the basic workspace. Can you spot the problem?~~

edit: found the problem, it works now.



